### PR TITLE
Unify waypoint parameters and fix Python 3.8 typing compatibility

### DIFF
--- a/Drone/Drone.py
+++ b/Drone/Drone.py
@@ -5,6 +5,7 @@
 # It includes methods for translational and rotational dynamics, state updates, and wind effects.
 
 import numpy as np
+from typing import List
 from Drone.Controller import QuadCopterController
 from Utils.utils import wrap_angle
 from Rotor.TorchRotorModel import RotorModel
@@ -60,7 +61,7 @@ class QuadcopterModel:
                     self.R_root = float(radius_sections.split(" ")[-1].strip())
                     self.R_tip = float(radius_sections.split(" ")[0].strip())
         
-        self.rotors: list[RotorModel] = []
+        self.rotors: List[RotorModel] = []
         for _ in range(n_rotors):
             rotor_model = RotorModel(1,6, norm_params_path="Rotor/normalization_params.pth")
             rotor_model.load_model(rotor_model_path)

--- a/Optimizations/optimizer.py
+++ b/Optimizations/optimizer.py
@@ -6,7 +6,7 @@ extend the initializer to parse configuration files or set up logging.
 """
 
 from __future__ import annotations
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, List
 
 
 class Optimizer:
@@ -22,7 +22,7 @@ class Optimizer:
         set_initial_obs: bool = True,
         simulate_wind_flag: bool = False,
         study_name: str = "",
-        waypoints: Optional[list] = None,
+        waypoints: Optional[List[dict]] = None,
         simulation_time: int = 150,
     ) -> None:
         self.name = name
@@ -44,8 +44,8 @@ class Optimizer:
         self.opt_output_path: str = ""
         self.iteration: int = 0
         self.best_cost: float = float("inf")
-        self.best_costs: list[float] = []
-        self.costs: list[float] = []
+        self.best_costs: List[float] = []
+        self.costs: List[float] = []
         self.noise_model: Any = None
 
     # ------------------------------------------------------------------

--- a/Optimizations/pid_optimization_bayopt.py
+++ b/Optimizations/pid_optimization_bayopt.py
@@ -5,7 +5,7 @@
 """Bayesian Optimization for PID tuning packaged into a class."""
 
 from time import time
-from typing import Dict, Optional
+from typing import Dict, Optional, List
 
 import numpy as np
 from bayes_opt import BayesianOptimization
@@ -50,7 +50,7 @@ class BayesianOptimizer(Optimizer):
         set_initial_obs: bool = True,
         simulate_wind_flag: bool = False,
         study_name: str = "",
-        waypoints: Optional[list] = None,
+        waypoints: Optional[List[dict]] = None,
         simulation_time: int = 150,
     ) -> None:
         super().__init__(
@@ -72,10 +72,11 @@ class BayesianOptimizer(Optimizer):
 
         # Base trajectory and PID
         self.base_pid = mainfunc.load_pid_gains(self.parameters)
+        params = self.parameters
         if waypoints is None:
-            n_points = int(bayopt_cfg.get("n_points", 5))
-            A = np.array(bayopt_cfg.get("A", [0.0, 0.0, 0.0]), dtype=float)
-            B = np.array(bayopt_cfg.get("B", [100.0, 100.0, 0.0]), dtype=float)
+            n_points = int(params.get("n_intermediate_waypoints", bayopt_cfg.get("n_points", 5)))
+            A = np.array(params.get("start_point", bayopt_cfg.get("A", [0.0, 0.0, 0.0])), dtype=float)
+            B = np.array(params.get("end_point", bayopt_cfg.get("B", [100.0, 100.0, 0.0])), dtype=float)
             line = np.linspace(A, B, n_points + 2)
             self.base_waypoints = [
                 {"x": float(p[0]), "y": float(p[1]), "z": float(p[2]), "v": 5}
@@ -90,10 +91,10 @@ class BayesianOptimizer(Optimizer):
         )
 
         pbounds_cfg = bayopt_cfg.get("pbounds", {})
+        perturb = float(params.get("waypoint_perturbation_range", bayopt_cfg.get("perturbation_range", 300.0)))
         if pbounds_cfg:
             self.pbounds = {k: tuple(v) for k, v in pbounds_cfg.items()}
         else:
-            perturb = float(bayopt_cfg.get("perturbation_range", 10.0))
             self.pbounds = {
                 f"p{i}_{ax}": (-perturb, perturb)
                 for i in range(self.n_points)
@@ -105,14 +106,14 @@ class BayesianOptimizer(Optimizer):
 
         self.iteration = 0
         self.best_target = -np.inf
-        self.best_params: Optional[list] = None
-        self.costs: list[float] = []
-        self.best_costs: list[float] = []
+        self.best_params: Optional[List[dict]] = None
+        self.costs: List[float] = []
+        self.best_costs: List[float] = []
 
     # ------------------------------------------------------------------
     # Utility methods
     # ------------------------------------------------------------------
-    def decode_vector(self, vec: np.ndarray) -> list[dict]:
+    def decode_vector(self, vec: np.ndarray) -> List[dict]:
         """Convert a flat vector into a list of waypoints."""
         pts = self.base_traj.copy()
         vec = vec.reshape(self.n_points, 3)
@@ -122,7 +123,7 @@ class BayesianOptimizer(Optimizer):
             for p in pts
         ]
 
-    def simulate_trajectory(self, waypoints: list) -> Dict[str, float]:
+    def simulate_trajectory(self, waypoints: List[dict]) -> Dict[str, float]:
         """Run a simulation with the given trajectory and return the cost metrics."""
         return run_simulation(
             self.base_pid,

--- a/Optimizations/pid_optimization_ga.py
+++ b/Optimizations/pid_optimization_ga.py
@@ -5,7 +5,7 @@
 """Genetic Algorithm for PID tuning packaged into a class."""
 
 from time import time
-from typing import Dict, Optional, Tuple
+from typing import Dict, Optional, Tuple, List
 
 import numpy as np
 
@@ -49,7 +49,7 @@ class GAOptimizer(Optimizer):
         set_initial_obs: bool = True,
         simulate_wind_flag: bool = False,
         study_name: str = "",
-        waypoints: Optional[list] = None,
+        waypoints: Optional[List[dict]] = None,
         simulation_time: int = 150,
     ) -> None:
         super().__init__(
@@ -75,10 +75,11 @@ class GAOptimizer(Optimizer):
 
         # Set up base trajectory between start and end points
         self.base_pid = mainfunc.load_pid_gains(self.parameters)
+        params = self.parameters
         if waypoints is None:
-            n_points = int(ga_cfg.get("n_points", 5))
-            A = np.array(ga_cfg.get("A", [0.0, 0.0, 0.0]), dtype=float)
-            B = np.array(ga_cfg.get("B", [100.0, 100.0, 0.0]), dtype=float)
+            n_points = int(params.get("n_intermediate_waypoints", ga_cfg.get("n_points", 5)))
+            A = np.array(params.get("start_point", ga_cfg.get("A", [0.0, 0.0, 0.0])), dtype=float)
+            B = np.array(params.get("end_point", ga_cfg.get("B", [100.0, 100.0, 0.0])), dtype=float)
             line = np.linspace(A, B, n_points + 2)
             self.base_waypoints = [
                 {"x": float(p[0]), "y": float(p[1]), "z": float(p[2]), "v": 5}
@@ -94,6 +95,7 @@ class GAOptimizer(Optimizer):
         )
 
         pbounds_cfg = ga_cfg.get("pbounds", {})
+        perturb = float(params.get("waypoint_perturbation_range", ga_cfg.get("perturbation_range", 300.0)))
         if pbounds_cfg:
             self.pbounds = {k: tuple(v) for k, v in pbounds_cfg.items()}
             self.lower_bounds = np.array(
@@ -103,7 +105,6 @@ class GAOptimizer(Optimizer):
                 [v[1] for v in self.pbounds.values()], dtype=float
             )
         else:
-            perturb = float(ga_cfg.get("perturbation_range", 10.0))
             self.lower_bounds = -perturb * np.ones(self.n_points * 3)
             self.upper_bounds = perturb * np.ones(self.n_points * 3)
             self.pbounds = {
@@ -113,8 +114,8 @@ class GAOptimizer(Optimizer):
             }
         self.dim = self.lower_bounds.size
 
-        self.costs: list[float] = []
-        self.best_costs: list[float] = []
+        self.costs: List[float] = []
+        self.best_costs: List[float] = []
         self.best_individual: Optional[np.ndarray] = None
         self.best_cost = np.inf
         self.elite_count = max(1, int(self.elite_fraction * self.population_size))
@@ -122,7 +123,7 @@ class GAOptimizer(Optimizer):
     # ------------------------------------------------------------------
     # Utility methods
     # ------------------------------------------------------------------
-    def decode_individual(self, vec: np.ndarray) -> list[dict]:
+    def decode_individual(self, vec: np.ndarray) -> List[dict]:
         """Convert an individual vector into a list of waypoints."""
         pts = self.base_traj.copy()
         vec = vec.reshape(self.n_points, 3)
@@ -132,7 +133,7 @@ class GAOptimizer(Optimizer):
             for p in pts
         ]
 
-    def simulate_trajectory(self, waypoints: list) -> Dict[str, float]:
+    def simulate_trajectory(self, waypoints: List[dict]) -> Dict[str, float]:
         """Run a simulation with the given trajectory and return the cost metrics."""
         return run_simulation(
             self.base_pid,

--- a/Optimizations/pid_optimization_gwo.py
+++ b/Optimizations/pid_optimization_gwo.py
@@ -5,7 +5,7 @@
 """Grey Wolf Optimization for PID tuning packaged into a class."""
 
 from time import time
-from typing import Dict, Optional
+from typing import Dict, Optional, List
 
 import numpy as np
 
@@ -50,7 +50,7 @@ class GWOOptimizer(Optimizer):
         set_initial_obs: bool = True,
         simulate_wind_flag: bool = False,
         study_name: str = "",
-        waypoints: Optional[list] = None,
+        waypoints: Optional[List[dict]] = None,
         simulation_time: int = 150,
     ) -> None:
         super().__init__(
@@ -72,10 +72,11 @@ class GWOOptimizer(Optimizer):
 
         # Base trajectory and PID
         self.base_pid = mainfunc.load_pid_gains(self.parameters)
+        params = self.parameters
         if waypoints is None:
-            n_points = int(gwo_cfg.get("n_points", 5))
-            A = np.array(gwo_cfg.get("A", [0.0, 0.0, 0.0]), dtype=float)
-            B = np.array(gwo_cfg.get("B", [100.0, 100.0, 0.0]), dtype=float)
+            n_points = int(params.get("n_intermediate_waypoints", gwo_cfg.get("n_points", 5)))
+            A = np.array(params.get("start_point", gwo_cfg.get("A", [0.0, 0.0, 0.0])), dtype=float)
+            B = np.array(params.get("end_point", gwo_cfg.get("B", [100.0, 100.0, 0.0])), dtype=float)
             line = np.linspace(A, B, n_points + 2)
             self.base_waypoints = [
                 {"x": float(p[0]), "y": float(p[1]), "z": float(p[2]), "v": 5}
@@ -90,6 +91,7 @@ class GWOOptimizer(Optimizer):
         )
 
         pbounds_cfg = gwo_cfg.get("pbounds", {})
+        perturb = float(params.get("waypoint_perturbation_range", gwo_cfg.get("perturbation_range", 300.0)))
         if pbounds_cfg:
             self.pbounds = {k: tuple(v) for k, v in pbounds_cfg.items()}
             self.lower_bounds = np.array(
@@ -99,7 +101,6 @@ class GWOOptimizer(Optimizer):
                 [v[1] for v in self.pbounds.values()], dtype=float
             )
         else:
-            perturb = float(gwo_cfg.get("perturbation_range", 10.0))
             self.lower_bounds = -perturb * np.ones(self.n_points * 3)
             self.upper_bounds = perturb * np.ones(self.n_points * 3)
             self.pbounds = {
@@ -109,13 +110,13 @@ class GWOOptimizer(Optimizer):
             }
         self.dim = self.lower_bounds.size
 
-        self.costs: list[float] = []
-        self.best_costs: list[float] = []
+        self.costs: List[float] = []
+        self.best_costs: List[float] = []
 
     # ------------------------------------------------------------------
     # Utility methods
     # ------------------------------------------------------------------
-    def decode_wolf(self, vec: np.ndarray) -> list[dict]:
+    def decode_wolf(self, vec: np.ndarray) -> List[dict]:
         """Convert a wolf vector into a list of waypoints."""
         pts = self.base_traj.copy()
         vec = vec.reshape(self.n_points, 3)
@@ -125,7 +126,7 @@ class GWOOptimizer(Optimizer):
             for p in pts
         ]
 
-    def simulate_trajectory(self, waypoints: list) -> Dict[str, float]:
+    def simulate_trajectory(self, waypoints: List[dict]) -> Dict[str, float]:
         """Run a simulation with the given trajectory and return the cost metrics."""
         return run_simulation(
             self.base_pid,

--- a/Optimizations/pid_optimization_pso.py
+++ b/Optimizations/pid_optimization_pso.py
@@ -5,7 +5,7 @@
 """Particle Swarm Optimization for PID tuning packaged into a class."""
 
 from time import time
-from typing import Dict, Optional
+from typing import Dict, Optional, List
 
 import numpy as np
 
@@ -50,7 +50,7 @@ class PSOOptimizer(Optimizer):
         set_initial_obs: bool = True,
         simulate_wind_flag: bool = False,
         study_name: str = "",
-        waypoints: Optional[list] = None,
+        waypoints: Optional[List[dict]] = None,
         simulation_time: int = 150,
     ) -> None:
         super().__init__(
@@ -75,10 +75,11 @@ class PSOOptimizer(Optimizer):
 
         # Base trajectory and PID
         self.base_pid = mainfunc.load_pid_gains(self.parameters)
+        params = self.parameters
         if waypoints is None:
-            n_points = int(pso_cfg.get("n_points", 5))
-            A = np.array(pso_cfg.get("A", [0.0, 0.0, 0.0]), dtype=float)
-            B = np.array(pso_cfg.get("B", [100.0, 100.0, 0.0]), dtype=float)
+            n_points = int(params.get("n_intermediate_waypoints", pso_cfg.get("n_points", 5)))
+            A = np.array(params.get("start_point", pso_cfg.get("A", [0.0, 0.0, 0.0])), dtype=float)
+            B = np.array(params.get("end_point", pso_cfg.get("B", [100.0, 100.0, 0.0])), dtype=float)
             line = np.linspace(A, B, n_points + 2)
             self.base_waypoints = [
                 {"x": float(p[0]), "y": float(p[1]), "z": float(p[2]), "v": 5}
@@ -93,6 +94,7 @@ class PSOOptimizer(Optimizer):
         )
 
         pbounds_cfg = pso_cfg.get("pbounds", {})
+        perturb = float(params.get("waypoint_perturbation_range", pso_cfg.get("perturbation_range", 300.0)))
         if pbounds_cfg:
             self.pbounds = {k: tuple(v) for k, v in pbounds_cfg.items()}
             self.lower_bounds = np.array(
@@ -102,7 +104,6 @@ class PSOOptimizer(Optimizer):
                 [v[1] for v in self.pbounds.values()], dtype=float
             )
         else:
-            perturb = float(pso_cfg.get("perturbation_range", 10.0))
             self.lower_bounds = -perturb * np.ones(self.n_points * 3)
             self.upper_bounds = perturb * np.ones(self.n_points * 3)
             self.pbounds = {
@@ -112,15 +113,15 @@ class PSOOptimizer(Optimizer):
             }
         self.dim = self.lower_bounds.size
 
-        self.costs: list[float] = []
-        self.best_costs: list[float] = []
+        self.costs: List[float] = []
+        self.best_costs: List[float] = []
         self.global_best_pos: Optional[np.ndarray] = None
         self.global_best_cost = np.inf
 
     # ------------------------------------------------------------------
     # Utility methods
     # ------------------------------------------------------------------
-    def decode_particle(self, vec: np.ndarray) -> list[dict]:
+    def decode_particle(self, vec: np.ndarray) -> List[dict]:
         """Convert a particle vector into a list of waypoints."""
         pts = self.base_traj.copy()
         vec = vec.reshape(self.n_points, 3)
@@ -130,7 +131,7 @@ class PSOOptimizer(Optimizer):
             for p in pts
         ]
 
-    def simulate_trajectory(self, waypoints: list) -> Dict[str, float]:
+    def simulate_trajectory(self, waypoints: List[dict]) -> Dict[str, float]:
         """Run a simulation with the given trajectory and return the cost metrics."""
         return run_simulation(
             self.base_pid,

--- a/Settings/simulation_parameters.yaml
+++ b/Settings/simulation_parameters.yaml
@@ -17,6 +17,12 @@ max_v_speed_limit_kmh: 20.0
 max_angle_limit_deg: 30.0
 anti_windup_contrib: 0.4
 
+# Trajectory parameters
+start_point: [0.0, 0.0, 0.0]
+end_point: [100.0, 100.0, 0.0]
+n_intermediate_waypoints: 5
+waypoint_perturbation_range: 300.0
+
 # Rotor model parameters
 norm_params_path: "Rotor/normalization_params.pth"
 rotor_model_path: "Rotor/rotor_model.pth"


### PR DESCRIPTION
## Summary
- Add start/end points, number of intermediate waypoints and perturbation range to `simulation_parameters.yaml`
- Update GA, GWO, PSO and Bayesian optimizers to pull waypoint settings from the shared parameters file and use `typing.List` generics for Python 3.8 compatibility
- Adjust base `Optimizer` and drone model to remove usage of built-in generic annotations

## Testing
- `python -m py_compile $(git ls-files '*.py')` *(warning: Rotor/pybemt/rotor.py:172: SyntaxWarning: invalid escape sequence '\c')*

------
https://chatgpt.com/codex/tasks/task_e_68c13cd359fc832baec48389bc4dc636