### PR TITLE
Add SAC reinforcement learning framework

### DIFF
--- a/RL/__init__.py
+++ b/RL/__init__.py
@@ -1,0 +1,4 @@
+"""RL package exposing SAC training utilities."""
+from RL.trainer import SACTrajectoryTrainer
+
+__all__ = ["SACTrajectoryTrainer"]

--- a/RL/callbacks.py
+++ b/RL/callbacks.py
@@ -1,0 +1,22 @@
+"""Custom callbacks used during RL training."""
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from stable_baselines3.common.callbacks import BaseCallback
+
+
+class RLEpisodeLogger(BaseCallback):
+    """Callback that forwards episode summaries to the trainer."""
+
+    def __init__(self, trainer: "BaseRLTrainer", verbose: int = 0) -> None:
+        super().__init__(verbose)
+        self.trainer = trainer
+
+    def _on_step(self) -> bool:
+        infos: List[Dict[str, Any]] = self.locals.get("infos", [])  # type: ignore[assignment]
+        for info in infos:
+            data = info.get("episode_data")
+            if data:
+                self.trainer.record_episode(data)
+        return True

--- a/RL/environment.py
+++ b/RL/environment.py
@@ -1,0 +1,228 @@
+"""Gymnasium environment for drone trajectory optimization with SAC."""
+from __future__ import annotations
+
+import os
+from copy import deepcopy
+from typing import Dict, List, Optional, Tuple
+
+import numpy as np
+from gymnasium import Env, spaces
+
+from Drone.Simulation import Simulation
+from Optimizations.optimizer import MetaHeuristicOptimizer
+
+
+class CostEvaluator(MetaHeuristicOptimizer):
+    """Lightweight wrapper to reuse the metaheuristic cost function in RL."""
+
+    def __init__(self, simulation_object: Simulation, name: str = "RL_COST") -> None:
+        super().__init__(
+            simulation_object=simulation_object,
+            opt_method_name=name,
+            config_file=None,
+            verbose=False,
+            set_initial_obs=False,
+        )
+        # Override base directory to keep RL assets under the RL folder
+        self.base_dir = os.path.join("RL", name)
+        os.makedirs(self.base_dir, exist_ok=True)
+
+    def optimize(self):
+        raise NotImplementedError("CostEvaluator does not implement an optimization routine.")
+
+
+class DroneTrajectoryEnv(Env):
+    """Environment where the agent sequentially designs intermediate waypoints."""
+
+    metadata = {"render_modes": []}
+
+    def __init__(
+        self,
+        simulation: Simulation,
+        cost_evaluator: CostEvaluator,
+        start_point: Tuple[float, float, float],
+        final_target: Tuple[float, float, float],
+        max_waypoints: int,
+        action_bounds: Dict[str, List[float]],
+        termination_distance: float,
+        cost_parameters: Optional[Dict[str, float]] = None,
+    ) -> None:
+        super().__init__()
+        self.simulation = simulation
+        self.cost_evaluator = cost_evaluator
+        self.start_point = np.array(start_point, dtype=float)
+        self.final_target = np.array(final_target, dtype=float)
+        self.max_waypoints = int(max_waypoints)
+        self.termination_distance = float(termination_distance)
+        self.cost_parameters = cost_parameters or {}
+
+        self.low_action = np.array(action_bounds.get("low", [0.0, 0.0, 0.0, 0.0]), dtype=np.float32)
+        self.high_action = np.array(action_bounds.get("high", [1000.0, 1000.0, 200.0, 20.0]), dtype=np.float32)
+        if self.low_action.shape != (4,) or self.high_action.shape != (4,):
+            raise ValueError("action_bounds must define 'low' and 'high' arrays with four elements each.")
+
+        self.action_space = spaces.Box(low=self.low_action, high=self.high_action, dtype=np.float32)
+
+        state_dim = self._compute_state_dimension()
+        obs_low = np.full(state_dim, -np.inf, dtype=np.float32)
+        obs_high = np.full(state_dim, np.inf, dtype=np.float32)
+        self.observation_space = spaces.Box(low=obs_low, high=obs_high, dtype=np.float32)
+
+        self.current_waypoints: List[Dict[str, float]] = []
+        self.current_step = 0
+        self._needs_reset = True
+        self.last_episode_data: Optional[Dict] = None
+
+    # ------------------------------------------------------------------
+    # Gymnasium API
+    # ------------------------------------------------------------------
+    def reset(self, *, seed: Optional[int] = None, options: Optional[Dict] = None):  # type: ignore[override]
+        super().reset(seed=seed)
+        del options  # unused
+
+        self.current_waypoints = []
+        self.current_step = 0
+        self._needs_reset = True
+        self.last_episode_data = None
+
+        # Restore simulation state to the initial conditions
+        self.simulation._clear_histories()  # type: ignore[attr-defined]
+        self.simulation.drone.reset_state()
+        self.simulation.drone.state['pos'] = self.start_point.copy()
+        self.simulation.drone.init_state['pos'] = self.start_point.copy()
+        self.simulation.current_seg_idx = 0
+        self.simulation.waypoints = []
+
+        observation = self._get_observation()
+        info: Dict = {}
+        return observation, info
+
+    def step(self, action: np.ndarray):  # type: ignore[override]
+        action = np.clip(action, self.low_action, self.high_action).astype(float)
+        waypoint = self._build_waypoint(action)
+        self.current_waypoints.append(waypoint)
+        self.simulation.waypoints = [deepcopy(waypoint)]
+        self.simulation.current_seg_idx = 0
+
+        reset_state = self._needs_reset
+        self._needs_reset = False
+
+        self.simulation.startSimulation(
+            stop_at_target=True,
+            verbose=False,
+            stop_sim_if_not_moving=True,
+            use_static_target=False,
+            reset_drone_state=reset_state,
+        )
+
+        costs = self._calculate_costs()
+        reward = -float(costs['total_cost'])
+
+        terminated = False
+        truncated = False
+        info: Dict = {
+            'costs': costs,
+            'waypoint': waypoint,
+            'trajectory': deepcopy(self.current_waypoints),
+        }
+
+        self.current_step += 1
+        drone_position = self.simulation.drone.state['pos']
+        reached_goal = np.linalg.norm(drone_position - self.final_target) <= self.termination_distance
+        exhausted_budget = self.current_step >= self.max_waypoints
+
+        if reached_goal or exhausted_budget:
+            if not reached_goal:
+                # Force the final leg toward the endpoint
+                final_wp = self._build_waypoint(np.concatenate((self.final_target, [self.high_action[-1]])))
+                self.simulation.waypoints = [final_wp]
+                self.simulation.current_seg_idx = 0
+                self.simulation.startSimulation(
+                    stop_at_target=True,
+                    verbose=False,
+                    stop_sim_if_not_moving=True,
+                    use_static_target=False,
+                    reset_drone_state=False,
+                )
+                self.current_waypoints.append(final_wp)
+                costs = self._calculate_costs()
+                reward = -float(costs['total_cost'])
+                info['costs'] = costs
+                info['trajectory'] = deepcopy(self.current_waypoints)
+            else:
+                # Ensure the final target is explicitly stored in the trajectory
+                if np.linalg.norm(self.final_target - np.array([
+                    info['trajectory'][-1]['x'],
+                    info['trajectory'][-1]['y'],
+                    info['trajectory'][-1]['z']
+                ])) > 1e-6:
+                    final_wp = self._build_waypoint(np.concatenate((self.final_target, [info['trajectory'][-1]['v']])))
+                    self.current_waypoints.append(final_wp)
+                    info['trajectory'] = deepcopy(self.current_waypoints)
+
+            terminated = True
+            self.last_episode_data = {
+                'trajectory': deepcopy(self.current_waypoints),
+                'total_cost': float(costs['total_cost']),
+                'costs': {k: float(v) for k, v in costs.items()},
+            }
+            info['episode_data'] = deepcopy(self.last_episode_data)
+
+        observation = self._get_observation()
+        return observation, reward, terminated, truncated, info
+
+    # ------------------------------------------------------------------
+    # Helper functions
+    # ------------------------------------------------------------------
+    def _calculate_costs(self) -> Dict[str, float]:
+        kwargs = dict(self.cost_parameters)
+        kwargs.setdefault('save_costs_in_history', False)
+        result = self.cost_evaluator.calculate_costs(**kwargs)
+        return {k: float(v) for k, v in result.items()}
+
+    def _build_waypoint(self, action: np.ndarray) -> Dict[str, float]:
+        return {
+            'x': float(action[0]),
+            'y': float(action[1]),
+            'z': float(action[2]),
+            'v': float(action[3]),
+        }
+
+    def _get_observation(self) -> np.ndarray:
+        state = self.simulation.drone.state
+        obs_components = [
+            np.asarray(state.get('pos', np.zeros(3)), dtype=np.float32),
+            np.asarray(state.get('vel', np.zeros(3)), dtype=np.float32),
+            np.asarray(state.get('angles', np.zeros(3)), dtype=np.float32),
+            np.asarray(state.get('ang_vel', np.zeros(3)), dtype=np.float32),
+            np.asarray(state.get('rpm', np.zeros(4)), dtype=np.float32),
+        ]
+        thrust = state.get('thrust', 0.0)
+        power = state.get('power', 0.0)
+        thrust_val = float(np.sum(thrust)) if np.size(thrust) else float(thrust)
+        power_val = float(np.sum(power)) if np.size(power) else float(power)
+        obs_components.append(np.array([thrust_val, power_val], dtype=np.float32))
+        steps_left = np.array([float(self.max_waypoints - self.current_step)], dtype=np.float32)
+        obs_components.append(steps_left)
+        return np.concatenate(obs_components, dtype=np.float32)
+
+    def _compute_state_dimension(self) -> int:
+        dummy_state = {
+            'pos': np.zeros(3),
+            'vel': np.zeros(3),
+            'angles': np.zeros(3),
+            'ang_vel': np.zeros(3),
+            'rpm': np.zeros(4),
+            'thrust': 0.0,
+            'power': 0.0,
+        }
+        dummy_obs = [
+            np.asarray(dummy_state['pos'], dtype=np.float32),
+            np.asarray(dummy_state['vel'], dtype=np.float32),
+            np.asarray(dummy_state['angles'], dtype=np.float32),
+            np.asarray(dummy_state['ang_vel'], dtype=np.float32),
+            np.asarray(dummy_state['rpm'], dtype=np.float32),
+            np.array([float(dummy_state['thrust']), float(dummy_state['power'])], dtype=np.float32),
+            np.array([0.0], dtype=np.float32),
+        ]
+        return int(np.sum([arr.size for arr in dummy_obs]))

--- a/RL/run_sac.py
+++ b/RL/run_sac.py
@@ -1,0 +1,36 @@
+"""Entry point for launching SAC training."""
+from __future__ import annotations
+
+import argparse
+import os
+
+from RL.trainer import SACTrajectoryTrainer
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Train a SAC agent for drone trajectory optimization.")
+    parser.add_argument(
+        "--config",
+        type=str,
+        default=os.path.join("Settings", "rl_parameters.yaml"),
+        help="Path to the RL configuration file.",
+    )
+    parser.add_argument(
+        "--study-name",
+        type=str,
+        default="",
+        help="Optional label appended to the results folder.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    trainer = SACTrajectoryTrainer(config_file=args.config)
+    if args.study_name:
+        trainer.study_name = args.study_name
+    trainer.start_optimization()
+
+
+if __name__ == "__main__":
+    main()

--- a/RL/trainer.py
+++ b/RL/trainer.py
@@ -1,0 +1,223 @@
+"""Training utilities for SAC-based drone trajectory optimization."""
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Dict, Iterable, List, Optional
+
+import yaml
+from gymnasium.vector import DummyVecEnv
+from stable_baselines3 import SAC
+
+from Drone.Simulation import Simulation
+from Optimizations.optimizer import MetaHeuristicOptimizer
+from Worlds.World import World
+from RL.callbacks import RLEpisodeLogger
+from RL.environment import CostEvaluator, DroneTrajectoryEnv
+from main import (
+    create_initial_state,
+    create_quadcopter_controller,
+    create_quadcopter_model,
+    get_max_thrust_from_rotor_model,
+    load_dnn_noise_model,
+    load_parameters,
+    load_pid_gains,
+)
+
+
+class BaseRLTrainer(MetaHeuristicOptimizer):
+    """Base class that bridges the RL workflow with the metaheuristic utilities."""
+
+    def __init__(self, config_file: str, verbose: bool = True) -> None:
+        with open(config_file, "r", encoding="utf-8") as stream:
+            rl_cfg = yaml.safe_load(stream)
+
+        self.rl_config = rl_cfg
+        self.simulation_parameters_path = rl_cfg["simulation_parameters_file"]
+        self.simulation_parameters = load_parameters(self.simulation_parameters_path)
+        self.start_point = tuple(self.simulation_parameters["start_point"])  # type: ignore[assignment]
+        self.end_point = tuple(self.simulation_parameters["end_point"])  # type: ignore[assignment]
+
+        simulation = self._create_simulation()
+
+        opt_name = rl_cfg.get("algorithm_name", "SAC")
+        super().__init__(
+            simulation_object=simulation,
+            opt_method_name=opt_name,
+            config_file=config_file,
+            verbose=verbose,
+            set_initial_obs=rl_cfg.get("set_initial_obs", True),
+        )
+        self.base_dir = os.path.join("RL", opt_name)
+        os.makedirs(self.base_dir, exist_ok=True)
+
+        self.cost_parameters = rl_cfg.get("cost_parameters", {})
+        self.best_cost: float = float("inf")
+        self.best_trajectory: List[Dict[str, float]] = []
+        self.model: Optional[SAC] = None
+
+    # ------------------------------------------------------------------
+    # Abstract API
+    # ------------------------------------------------------------------
+    def optimize(self) -> List[Dict[str, float]]:  # type: ignore[override]
+        raise NotImplementedError
+
+    # ------------------------------------------------------------------
+    # Shared helpers
+    # ------------------------------------------------------------------
+    def _create_simulation(self) -> Simulation:
+        params = self.simulation_parameters
+        init_state = create_initial_state(*self.start_point)
+        pid_gains = load_pid_gains(params)
+        thrust_max = get_max_thrust_from_rotor_model(params)
+        controller = create_quadcopter_controller(init_state, pid_gains, thrust_max, params)
+        drone = create_quadcopter_model(init_state, controller, params)
+        world_path = params["world_data_path"]
+        if os.path.exists(world_path):
+            world = World.load_world(world_path)
+        else:
+            grid_size = int(params.get("grid_size", 10))
+            max_world_size = int(params.get("max_world_size", 1000))
+            world = World(grid_size=grid_size, max_world_size=max_world_size)
+        noise_model = load_dnn_noise_model(params)
+        simulation = Simulation(
+            drone=drone,
+            world=world,
+            waypoints=[],
+            dt=float(params["dt"]),
+            max_simulation_time=float(params["simulation_time"]),
+            frame_skip=int(params["frame_skip"]),
+            target_reached_threshold=float(params["threshold"]),
+            target_shift_threshold_distance=float(params["target_shift_threshold_distance"]),
+            noise_model=noise_model,
+            noise_annoyance_radius=int(params["noise_annoyance_radius"]),
+            generate_sound_emission_map=False,
+            compute_psychoacoustics=False,
+        )
+        return simulation
+
+    def _build_env_factory(self):
+        max_waypoints = int(self.rl_config.get("max_waypoints", 10))
+        termination_distance = float(self.rl_config.get("termination_distance", 5.0))
+        action_bounds = self.rl_config.get("action_bounds", {})
+
+        def _factory() -> DroneTrajectoryEnv:
+            simulation = self._create_simulation()
+            cost_evaluator = CostEvaluator(simulation, name=f"{self.opt_method_name}_COST")
+            env = DroneTrajectoryEnv(
+                simulation=simulation,
+                cost_evaluator=cost_evaluator,
+                start_point=self.start_point,
+                final_target=self.end_point,
+                max_waypoints=max_waypoints,
+                action_bounds=action_bounds,
+                termination_distance=termination_distance,
+                cost_parameters=self.cost_parameters,
+            )
+            return env
+
+        return _factory
+
+    def record_episode(self, episode_data: Dict[str, Any]) -> None:
+        total_cost = float(episode_data["total_cost"])
+        trajectory = self._convert_waypoints(episode_data["trajectory"])
+        self.costs_history.append(total_cost)
+        self.costs_dict_history.append(episode_data["costs"])
+        self.log_step(trajectory)
+        if total_cost < self.best_cost:
+            self.best_cost = total_cost
+            self.best_trajectory = trajectory
+
+    @staticmethod
+    def _convert_waypoints(raw_waypoints: Iterable[Dict[str, Any]]) -> List[Dict[str, float]]:
+        return [
+            {
+                "x": float(wp["x"]),
+                "y": float(wp["y"]),
+                "z": float(wp["z"]),
+                "v": float(wp["v"]),
+            }
+            for wp in raw_waypoints
+        ]
+
+    def save_results_in_file(self, best_params) -> None:  # type: ignore[override]
+        results = {
+            "Optimization Algorithm": self.opt_method_name,
+            "Best Parameters Found": best_params,
+            "Best Cost": float(self.best_cost) if self.costs_history else None,
+            "Total time (s)": self.end_time,
+            "Number of iterations": len(self.costs_history),
+            "Avg step time (s)": self.end_time / len(self.costs_history) if self.costs_history else None,
+            "Optimization Parameters": self.cfg,
+        }
+        results_path = os.path.join(self.study_dir, "optimization_results.json")
+        with open(results_path, "w", encoding="utf-8") as file:
+            json.dump(results, file, indent=4)
+        print(f"{self.get_alg_prefix()} Results saved to {results_path}")
+
+
+class SACTrajectoryTrainer(BaseRLTrainer):
+    """Trainer that leverages Stable-Baselines3 SAC."""
+
+    def optimize(self) -> List[Dict[str, float]]:  # type: ignore[override]
+        env_factory = self._build_env_factory()
+        train_env = DummyVecEnv([env_factory])
+
+        sac_kwargs = self._build_sac_kwargs(train_env)
+        model = SAC(**sac_kwargs)
+        self.model = model
+
+        callback = RLEpisodeLogger(self)
+        total_timesteps = int(self.rl_config.get("total_timesteps", 10_000))
+        log_interval = self.rl_config.get("log_interval", 1)
+
+        try:
+            model.learn(total_timesteps=total_timesteps, callback=callback, log_interval=log_interval)
+        finally:
+            train_env.close()
+
+        if self.study_dir:
+            model_path = os.path.join(self.study_dir, "sac_model")
+            model.save(model_path)
+            print(f"{self.get_alg_prefix()} Model saved to {model_path}")
+
+        eval_episodes = int(self.rl_config.get("evaluation_episodes", 3))
+        if eval_episodes > 0:
+            self._evaluate_policy(model, env_factory, eval_episodes)
+
+        return self.best_trajectory
+
+    def _evaluate_policy(self, model: SAC, env_factory, episodes: int) -> None:
+        for _ in range(episodes):
+            env = env_factory()
+            obs, _ = env.reset()
+            done = False
+            truncated = False
+            while not (done or truncated):
+                action, _ = model.predict(obs, deterministic=True)
+                obs, _, done, truncated, info = env.step(action)
+            episode_data = info.get("episode_data")
+            if episode_data:
+                self.record_episode(episode_data)
+            env.close()
+
+    def _build_sac_kwargs(self, env: DummyVecEnv) -> Dict[str, Any]:
+        policy = self.rl_config.get("policy", "MlpPolicy")
+        kwargs: Dict[str, Any] = {
+            "policy": policy,
+            "env": env,
+            "learning_rate": self.rl_config.get("learning_rate", 3e-4),
+            "buffer_size": int(self.rl_config.get("buffer_size", 100_000)),
+            "batch_size": int(self.rl_config.get("batch_size", 256)),
+            "tau": self.rl_config.get("tau", 0.005),
+            "gamma": self.rl_config.get("gamma", 0.99),
+            "train_freq": self.rl_config.get("train_freq", 1),
+            "gradient_steps": self.rl_config.get("gradient_steps", 1),
+            "ent_coef": self.rl_config.get("ent_coef", "auto"),
+            "target_update_interval": int(self.rl_config.get("target_update_interval", 1)),
+            "learning_starts": int(self.rl_config.get("learning_starts", 1_000)),
+            "device": self.rl_config.get("device", "auto"),
+        }
+        if self.rl_config.get("policy_kwargs"):
+            kwargs["policy_kwargs"] = self.rl_config["policy_kwargs"]
+        return kwargs

--- a/Settings/rl_parameters.yaml
+++ b/Settings/rl_parameters.yaml
@@ -1,0 +1,34 @@
+# Reinforcement learning configuration for SAC
+algorithm_name: "SAC"
+set_initial_obs: true
+simulation_parameters_file: "Settings/simulation_parameters.yaml"
+
+# Environment settings
+max_waypoints: 10
+termination_distance: 5.0
+action_bounds:
+  low: [0.0, 0.0, 0.0, 2.0]
+  high: [1000.0, 1000.0, 200.0, 20.0]
+cost_parameters:
+  altitude_weight: 0.01
+  power_weight: 0.0001
+  noise_weight: 15.0
+  completion_weight: 1000.0
+  save_costs_in_history: false
+
+# SAC hyperparameters
+total_timesteps: 2000
+learning_rate: 0.0003
+buffer_size: 50000
+batch_size: 128
+gamma: 0.99
+tau: 0.005
+train_freq: 1
+gradient_steps: 1
+ent_coef: "auto"
+target_update_interval: 1
+learning_starts: 1000
+policy: "MlpPolicy"
+log_interval: 1
+device: "auto"
+evaluation_episodes: 1


### PR DESCRIPTION
## Summary
- add a dedicated RL package with a Gymnasium environment that continues the drone simulation segment-by-segment and reuses the existing cost function
- introduce a SAC-based trainer that logs costs with the shared metaheuristic utilities and exposes a CLI entrypoint for training
- provide YAML configuration for environment limits, hyperparameters, and simulation settings

## Testing
- python -m compileall RL

------
https://chatgpt.com/codex/tasks/task_e_68d4e44de5c4832b89bcad02fc718b07