### PR TITLE
Add baseline straight-line episode for SAC training

### DIFF
--- a/RL/environment.py
+++ b/RL/environment.py
@@ -56,12 +56,41 @@ class DroneTrajectoryEnv(Env):
         self.termination_distance = float(termination_distance)
         self.cost_parameters = cost_parameters or {}
 
-        self.low_action = np.array(action_bounds.get("low", [0.0, 0.0, 0.0, 0.0]), dtype=np.float32)
-        self.high_action = np.array(action_bounds.get("high", [1000.0, 1000.0, 200.0, 20.0]), dtype=np.float32)
-        if self.low_action.shape != (4,) or self.high_action.shape != (4,):
-            raise ValueError("action_bounds must define 'low' and 'high' arrays with four elements each.")
+        raw_low = np.array(action_bounds.get("low", [-100.0, -100.0, -100.0, 0.0, 0.0]), dtype=float)
+        raw_high = np.array(action_bounds.get("high", [100.0, 100.0, 100.0, 20.0, 1.0]), dtype=float)
+
+        if raw_low.shape not in {(4,), (5,)} or raw_high.shape != raw_low.shape:
+            raise ValueError(
+                "action_bounds must define 'low' and 'high' arrays with four or five elements each."
+            )
+
+        if raw_low.shape == (4,):
+            raw_low = np.concatenate([raw_low, [0.0]])
+            raw_high = np.concatenate([raw_high, [1.0]])
+
+        self.world_min_bounds, self.world_max_bounds = self._infer_world_bounds()
+        (
+            self.low_action,
+            self.high_action,
+            self.per_waypoint_low,
+            self.per_waypoint_high,
+        ) = self._initialize_action_bounds(raw_low, raw_high)
+
+        self.speed_index = 3
+        self.stop_action_index = 4 if self.low_action.size > 4 else None
+        self.stop_threshold = 0.5
 
         self.action_space = spaces.Box(low=self.low_action, high=self.high_action, dtype=np.float32)
+
+        # Reference internal waypoints on the direct A→B segment.
+        self.reference_points = np.asarray(
+            MetaHeuristicOptimizer.linspace_internal_points(
+                self.start_point,
+                self.final_target,
+                self.max_waypoints,
+            ),
+            dtype=float,
+        )
 
         state_dim = self._compute_state_dimension()
         obs_low = np.full(state_dim, -np.inf, dtype=np.float32)
@@ -99,7 +128,17 @@ class DroneTrajectoryEnv(Env):
 
     def step(self, action: np.ndarray):  # type: ignore[override]
         action = np.clip(action, self.low_action, self.high_action).astype(float)
-        waypoint = self._build_waypoint(action)
+        action = self._clip_action_for_index(action, self.current_step)
+
+        if self._should_request_stop(action):
+            return self._finalize_episode(
+                reached_goal=False,
+                forced_speed=float(action[self.speed_index]),
+                stopped_by_agent=True,
+                last_waypoint=None,
+            )
+
+        waypoint = self._build_waypoint(action, self.current_step)
         self.current_waypoints.append(waypoint)
         self.simulation.waypoints = [deepcopy(waypoint)]
         self.simulation.current_seg_idx = 0
@@ -124,6 +163,7 @@ class DroneTrajectoryEnv(Env):
             'costs': costs,
             'waypoint': waypoint,
             'trajectory': deepcopy(self.current_waypoints),
+            'stopped_by_agent': False,
         }
 
         self.current_step += 1
@@ -132,41 +172,13 @@ class DroneTrajectoryEnv(Env):
         exhausted_budget = self.current_step >= self.max_waypoints
 
         if reached_goal or exhausted_budget:
-            if not reached_goal:
-                # Force the final leg toward the endpoint
-                final_wp = self._build_waypoint(np.concatenate((self.final_target, [self.high_action[-1]])))
-                self.simulation.waypoints = [final_wp]
-                self.simulation.current_seg_idx = 0
-                self.simulation.startSimulation(
-                    stop_at_target=True,
-                    verbose=False,
-                    stop_sim_if_not_moving=True,
-                    use_static_target=False,
-                    reset_drone_state=False,
-                )
-                self.current_waypoints.append(final_wp)
-                costs = self._calculate_costs()
-                reward = -float(costs['total_cost'])
-                info['costs'] = costs
-                info['trajectory'] = deepcopy(self.current_waypoints)
-            else:
-                # Ensure the final target is explicitly stored in the trajectory
-                if np.linalg.norm(self.final_target - np.array([
-                    info['trajectory'][-1]['x'],
-                    info['trajectory'][-1]['y'],
-                    info['trajectory'][-1]['z']
-                ])) > 1e-6:
-                    final_wp = self._build_waypoint(np.concatenate((self.final_target, [info['trajectory'][-1]['v']])))
-                    self.current_waypoints.append(final_wp)
-                    info['trajectory'] = deepcopy(self.current_waypoints)
-
-            terminated = True
-            self.last_episode_data = {
-                'trajectory': deepcopy(self.current_waypoints),
-                'total_cost': float(costs['total_cost']),
-                'costs': {k: float(v) for k, v in costs.items()},
-            }
-            info['episode_data'] = deepcopy(self.last_episode_data)
+            return self._finalize_episode(
+                reached_goal=reached_goal,
+                forced_speed=float(action[self.speed_index]),
+                stopped_by_agent=False,
+                last_waypoint=waypoint,
+                cached_costs=costs if reached_goal else None,
+            )
 
         observation = self._get_observation()
         return observation, reward, terminated, truncated, info
@@ -174,18 +186,123 @@ class DroneTrajectoryEnv(Env):
     # ------------------------------------------------------------------
     # Helper functions
     # ------------------------------------------------------------------
+    def run_zero_waypoint_episode(self):
+        """Simulate an episode that travels directly from start to target."""
+
+        self.reset()
+        default_speed = self._default_terminal_speed()
+        return self._finalize_episode(
+            reached_goal=False,
+            forced_speed=default_speed,
+            stopped_by_agent=True,
+            last_waypoint=None,
+        )
+
     def _calculate_costs(self) -> Dict[str, float]:
         kwargs = dict(self.cost_parameters)
         kwargs.setdefault('save_costs_in_history', False)
         result = self.cost_evaluator.calculate_costs(**kwargs)
         return {k: float(v) for k, v in result.items()}
 
-    def _build_waypoint(self, action: np.ndarray) -> Dict[str, float]:
+    def _build_waypoint(self, action: np.ndarray, index: int) -> Dict[str, float]:
+        reference = self._get_reference_point(index)
+        offset = action[:3]
+        position = reference + offset
+        position = np.clip(position, self.world_min_bounds, self.world_max_bounds)
+        return self._build_absolute_waypoint(position, float(action[self.speed_index]))
+
+    def _should_request_stop(self, action: np.ndarray) -> bool:
+        if self.stop_action_index is None:
+            return False
+        stop_signal = float(action[self.stop_action_index])
+        return stop_signal <= self.stop_threshold
+
+    def _finalize_episode(
+        self,
+        reached_goal: bool,
+        forced_speed: float,
+        stopped_by_agent: bool,
+        last_waypoint: Optional[Dict[str, float]],
+        cached_costs: Optional[Dict[str, float]] = None,
+    ):
+        if reached_goal:
+            final_wp = self._ensure_final_target_present(
+                speed=(last_waypoint['v'] if last_waypoint else forced_speed),
+                run_simulation=False,
+            )
+            costs = cached_costs if cached_costs is not None else self._calculate_costs()
+            reward = -float(costs['total_cost'])
+        else:
+            final_wp = self._ensure_final_target_present(speed=forced_speed, run_simulation=True)
+            costs = self._calculate_costs()
+            reward = -float(costs['total_cost'])
+
+        info: Dict = {
+            'costs': costs,
+            'waypoint': last_waypoint if last_waypoint is not None else final_wp,
+            'trajectory': deepcopy(self.current_waypoints),
+            'stopped_by_agent': stopped_by_agent,
+        }
+
+        self.last_episode_data = {
+            'trajectory': deepcopy(self.current_waypoints),
+            'total_cost': float(costs['total_cost']),
+            'costs': {k: float(v) for k, v in costs.items()},
+        }
+        info['episode_data'] = deepcopy(self.last_episode_data)
+
+        observation = self._get_observation()
+        terminated = True
+        truncated = False
+        return observation, reward, terminated, truncated, info
+
+    def _ensure_final_target_present(self, speed: Optional[float], run_simulation: bool) -> Dict[str, float]:
+        last_wp = self.current_waypoints[-1] if self.current_waypoints else None
+        if last_wp is not None:
+            last_pos = np.array([last_wp['x'], last_wp['y'], last_wp['z']], dtype=float)
+            if np.linalg.norm(last_pos - self.final_target) <= 1e-6:
+                return last_wp
+
+        base_speed = speed if speed is not None else (
+            last_wp['v'] if last_wp is not None else self._default_terminal_speed()
+        )
+        final_wp = self._build_absolute_waypoint(self.final_target, float(base_speed))
+
+        if run_simulation:
+            reset_state = self._needs_reset
+            self.simulation.waypoints = [deepcopy(final_wp)]
+            self.simulation.current_seg_idx = 0
+            self.simulation.startSimulation(
+                stop_at_target=True,
+                verbose=False,
+                stop_sim_if_not_moving=True,
+                use_static_target=False,
+                reset_drone_state=reset_state,
+            )
+            self._needs_reset = False
+
+        self.current_waypoints.append(final_wp)
+        return final_wp
+
+    def _default_terminal_speed(self) -> float:
+        low = float(self.low_action[self.speed_index])
+        high = float(self.high_action[self.speed_index])
+        midpoint = 0.5 * (low + high)
+        return float(np.clip(midpoint, low, high))
+
+    def _get_reference_point(self, index: int) -> np.ndarray:
+        if self.reference_points.size == 0:
+            return self.final_target.astype(float)
+        clipped_index = min(max(index, 0), len(self.reference_points) - 1)
+        return self.reference_points[clipped_index]
+
+    @staticmethod
+    def _build_absolute_waypoint(position: np.ndarray, speed: float) -> Dict[str, float]:
         return {
-            'x': float(action[0]),
-            'y': float(action[1]),
-            'z': float(action[2]),
-            'v': float(action[3]),
+            'x': float(position[0]),
+            'y': float(position[1]),
+            'z': float(position[2]),
+            'v': float(speed),
         }
 
     def _get_observation(self) -> np.ndarray:
@@ -226,3 +343,80 @@ class DroneTrajectoryEnv(Env):
             np.array([0.0], dtype=np.float32),
         ]
         return int(np.sum([arr.size for arr in dummy_obs]))
+
+    def _infer_world_bounds(self) -> Tuple[np.ndarray, np.ndarray]:
+        world = getattr(self.simulation, "world", None)
+        world_min = np.zeros(3, dtype=float)
+        world_max_value: Optional[float] = None
+        if world is not None:
+            max_world_size = getattr(world, "max_world_size", None)
+            if max_world_size is not None:
+                try:
+                    world_max_value = float(max_world_size)
+                except (TypeError, ValueError):
+                    world_max_value = None
+
+        if world_max_value is None or world_max_value <= 0:
+            coords = np.vstack([self.start_point, self.final_target]) if self.start_point.size else np.zeros((0, 3))
+            fallback = float(np.max(coords)) if coords.size else 0.0
+            world_max_value = max(fallback, 1.0)
+
+        world_max = np.full(3, world_max_value, dtype=float)
+        return world_min, world_max
+
+    def _initialize_action_bounds(
+        self, raw_low: np.ndarray, raw_high: np.ndarray
+    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        if self.max_waypoints <= 0:
+            low_action = raw_low.astype(np.float32)
+            high_action = raw_high.astype(np.float32)
+            empty = np.zeros((0, raw_low.size), dtype=float)
+            return low_action, high_action, empty, empty
+
+        offset_candidates = np.concatenate((raw_low[:3], raw_high[:3]))
+        finite_candidates = np.abs(offset_candidates[np.isfinite(offset_candidates)])
+        max_offset = float(np.max(finite_candidates)) if finite_candidates.size else None
+        if max_offset is not None and max_offset <= 0:
+            max_offset = None
+
+        world_low_flat, world_high_flat = MetaHeuristicOptimizer.build_particle_bounds(
+            self.start_point,
+            self.final_target,
+            self.max_waypoints,
+            max_perturbation_offset=max_offset,
+            vmax=float(raw_high[3]),
+            world_min=float(self.world_min_bounds[0]),
+            world_max=float(self.world_max_bounds[0]),
+            v_min=float(raw_low[3]),
+        )
+
+        world_low = world_low_flat.reshape(self.max_waypoints, 4)
+        world_high = world_high_flat.reshape(self.max_waypoints, 4)
+        base_low_core = np.broadcast_to(raw_low[:4], (self.max_waypoints, 4))
+        base_high_core = np.broadcast_to(raw_high[:4], (self.max_waypoints, 4))
+
+        per_waypoint_low_core = np.maximum(world_low, base_low_core)
+        per_waypoint_high_core = np.minimum(world_high, base_high_core)
+
+        if raw_low.size > 4:
+            gating_low = np.broadcast_to(raw_low[4:], (self.max_waypoints, raw_low.size - 4))
+            gating_high = np.broadcast_to(raw_high[4:], (self.max_waypoints, raw_low.size - 4))
+            per_waypoint_low = np.concatenate((per_waypoint_low_core, gating_low), axis=1)
+            per_waypoint_high = np.concatenate((per_waypoint_high_core, gating_high), axis=1)
+        else:
+            per_waypoint_low = per_waypoint_low_core
+            per_waypoint_high = per_waypoint_high_core
+
+        if np.any(per_waypoint_low > per_waypoint_high):
+            raise ValueError("Inconsistent action bounds: some waypoint intervals are invalid.")
+
+        low_action = per_waypoint_low.min(axis=0).astype(np.float32)
+        high_action = per_waypoint_high.max(axis=0).astype(np.float32)
+
+        return low_action, high_action, per_waypoint_low, per_waypoint_high
+
+    def _clip_action_for_index(self, action: np.ndarray, index: int) -> np.ndarray:
+        if index < 0 or index >= len(self.per_waypoint_low):
+            return action
+        clipped = np.clip(action, self.per_waypoint_low[index], self.per_waypoint_high[index])
+        return clipped

--- a/RL/trainer.py
+++ b/RL/trainer.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import os
+from math import isclose
 from typing import Any, Dict, Iterable, List, Optional
 
 import yaml
@@ -121,15 +122,28 @@ class BaseRLTrainer(MetaHeuristicOptimizer):
 
         return _factory
 
+    def _run_zero_waypoint_episode(self, env_factory) -> None:
+        """Execute a baseline episode that keeps the trajectory as a straight line."""
+
+        env = env_factory()
+        try:
+            _, _, _, _, info = env.run_zero_waypoint_episode()
+            episode_data = info.get("episode_data") if info else None
+            if episode_data:
+                self.record_episode(episode_data)
+        finally:
+            env.close()
+
     def record_episode(self, episode_data: Dict[str, Any]) -> None:
         total_cost = float(episode_data["total_cost"])
         trajectory = self._convert_waypoints(episode_data["trajectory"])
+        absolute_trajectory = self._finalize_trajectory(trajectory)
         self.costs_history.append(total_cost)
         self.costs_dict_history.append(episode_data["costs"])
-        self.log_step(trajectory)
+        self.log_step(absolute_trajectory)
         if total_cost < self.best_cost:
             self.best_cost = total_cost
-            self.best_trajectory = trajectory
+            self.best_trajectory = absolute_trajectory
 
     @staticmethod
     def _convert_waypoints(raw_waypoints: Iterable[Dict[str, Any]]) -> List[Dict[str, float]]:
@@ -143,10 +157,45 @@ class BaseRLTrainer(MetaHeuristicOptimizer):
             for wp in raw_waypoints
         ]
 
+    def _finalize_trajectory(self, waypoints: Iterable[Dict[str, float]]) -> List[Dict[str, float]]:
+        """Return a copy of the waypoints with the terminal target appended if needed."""
+
+        sanitized = [
+            {
+                "x": float(wp["x"]),
+                "y": float(wp["y"]),
+                "z": float(wp["z"]),
+                "v": float(wp["v"]),
+            }
+            for wp in waypoints
+        ]
+
+        if not sanitized:
+            return sanitized
+
+        last = sanitized[-1]
+        target_x, target_y, target_z = self.end_point
+        if not (
+            isclose(last["x"], target_x, abs_tol=1e-6)
+            and isclose(last["y"], target_y, abs_tol=1e-6)
+            and isclose(last["z"], target_z, abs_tol=1e-6)
+        ):
+            sanitized.append(
+                {
+                    "x": float(target_x),
+                    "y": float(target_y),
+                    "z": float(target_z),
+                    "v": float(last["v"]),
+                }
+            )
+
+        return sanitized
+
     def save_results_in_file(self, best_params) -> None:  # type: ignore[override]
+        serialized_best = self._finalize_trajectory(best_params) if best_params else []
         results = {
             "Optimization Algorithm": self.opt_method_name,
-            "Best Parameters Found": best_params,
+            "Best Parameters Found": serialized_best,
             "Best Cost": float(self.best_cost) if self.costs_history else None,
             "Total time (s)": self.end_time,
             "Number of iterations": len(self.costs_history),
@@ -164,6 +213,7 @@ class SACTrajectoryTrainer(BaseRLTrainer):
 
     def optimize(self) -> List[Dict[str, float]]:  # type: ignore[override]
         env_factory = self._build_env_factory()
+        self._run_zero_waypoint_episode(env_factory)
         train_env = DummyVecEnv([env_factory])
 
         sac_kwargs = self._build_sac_kwargs(train_env)

--- a/Settings/rl_parameters.yaml
+++ b/Settings/rl_parameters.yaml
@@ -7,8 +7,8 @@ simulation_parameters_file: "Settings/simulation_parameters.yaml"
 max_waypoints: 10
 termination_distance: 5.0
 action_bounds:
-  low: [0.0, 0.0, 0.0, 2.0]
-  high: [1000.0, 1000.0, 500.0, 20.0]
+  low: [-250.0, -250.0, -250.0, 2.0, 0.0]
+  high: [250.0, 250.0, 250.0, 20.0, 1.0]
 cost_parameters:
   altitude_weight: 0.01
   power_weight: 0.0001


### PR DESCRIPTION
## Summary
- add a helper on the RL environment to simulate an episode that flies directly from the start to the goal without intermediate waypoints
- run that zero-waypoint baseline before SAC training so the straight-line trajectory is logged and tracked alongside learned rollouts

## Testing
- python -m compileall RL Settings

------
https://chatgpt.com/codex/tasks/task_e_68d54c244bdc832ba88af47638520fab